### PR TITLE
SEVERE: Fix wrong buffer passed to`_compress` when `_digestLength` < 64

### DIFF
--- a/lib/digests/blake2b.dart
+++ b/lib/digests/blake2b.dart
@@ -149,7 +149,7 @@ class Blake2bDigest extends BaseDigest implements Digest {
             .setRange(_bufferPos, _bufferPos + remainingLength, inp, inpOff);
         _t0.sum(_blockSize);
         if (_t0.lo32 == 0 && _t0.hi32 == 0) _t1.sum(1);
-        _compress(inp, 0);
+        _compress(_buffer, 0);
         _bufferPos = 0;
         _buffer!.fillRange(0, _buffer!.length, 0); // clear buffer
       } else {


### PR DESCRIPTION
The correct variable to be passed to `_compress` is `_buffer`, that was populated 3 lines above, not the method parameter `inp`.

To test this changed line you should create a `Blake2bDigest` with `digestSize` = 32.

See equivalent Java implementation line as reference:
https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/crypto/digests/Blake2bDigest.java#L353